### PR TITLE
Add CapStoneWebSVF6.0 as submodule under webSVF_capstones

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "webSVF_capstones/webSVF_4.0/CapstoneProject"]
 	path = webSVF_capstones/webSVF_4.0/CapstoneProject
 	url = https://github.com/IshaShroff/CapstoneProject.git
+[submodule "webSVF_capstones/CapStoneWebSVF6.0"]
+	path = webSVF_capstones/CapStoneWebSVF6.0
+	url = https://github.com/AditiSachan/CapStoneWebSVF6.0
+	branch = main


### PR DESCRIPTION
This PR adds the null-deref executable and the necessary changes to enable its detection.

While setting this up, we observed that even without the executable, the graph output differs from what we see in production webSVF5.0. Since SVF does not output the graphs by default anymore, Chris found the command to output the graphs and modified api/controller/Svfcontroller. However, the structure of these generated graphs looks different.

**Request:**
Could someone please review and confirm if this graph output difference is expected?